### PR TITLE
Harden sensor runtime logic and add host-side logic tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,11 @@ jobs:
           west init -l sensor
           west update -o=--depth=1 -n
 
+      - name: Install host compiler for logic tests
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends gcc libc6-dev
+
       - name: Run logic unit tests
         working-directory: sensor
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,11 @@ jobs:
           west init -l sensor
           west update -o=--depth=1 -n
 
+      - name: Run logic unit tests
+        working-directory: sensor
+        run: |
+          ./tests/logic/run_tests.sh
+
       - name: Build debug release
         working-directory: sensor
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 
 project("Schneggi Sensor")
 
-FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.c)
+FILE(GLOB_RECURSE app_sources CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/*.c)
 target_sources(app PRIVATE ${app_sources})
 
 target_include_directories(app PRIVATE include)

--- a/include/sensor_logic.h
+++ b/include/sensor_logic.h
@@ -1,0 +1,15 @@
+#ifndef SENSOR_LOGIC_H
+#define SENSOR_LOGIC_H
+
+#include <stdint.h>
+
+struct battery_level_point
+{
+	uint16_t lvl_pptt;
+	uint16_t lvl_mV;
+};
+
+unsigned int battery_level_pptt(unsigned int batt_mV, const struct battery_level_point *curve);
+uint16_t co2_ppm_to_attr_u16(double ppm, uint16_t max_value);
+
+#endif

--- a/include/sensor_logic.h
+++ b/include/sensor_logic.h
@@ -1,6 +1,7 @@
 #ifndef SENSOR_LOGIC_H
 #define SENSOR_LOGIC_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 struct battery_level_point
@@ -9,8 +10,18 @@ struct battery_level_point
 	uint16_t lvl_mV;
 };
 
+struct commissioning_state
+{
+	bool joining_signal_received;
+	bool stack_initialised;
+};
+
 unsigned int battery_level_pptt(unsigned int batt_mV, const struct battery_level_point *curve);
 uint16_t compute_battery_sleep_cycles(uint32_t battery_interval_seconds, uint32_t sleep_interval_seconds);
 uint16_t co2_ppm_to_attr_u16(double ppm, uint16_t max_value);
+void commissioning_on_skip_startup(struct commissioning_state *state);
+void commissioning_on_steering_result(struct commissioning_state *state, bool success);
+void commissioning_on_leave(struct commissioning_state *state);
+bool commissioning_should_reset_on_parent_link_failure(const struct commissioning_state *state);
 
 #endif

--- a/include/sensor_logic.h
+++ b/include/sensor_logic.h
@@ -10,6 +10,7 @@ struct battery_level_point
 };
 
 unsigned int battery_level_pptt(unsigned int batt_mV, const struct battery_level_point *curve);
+uint16_t compute_battery_sleep_cycles(uint32_t battery_interval_seconds, uint32_t sleep_interval_seconds);
 uint16_t co2_ppm_to_attr_u16(double ppm, uint16_t max_value);
 
 #endif

--- a/scripts/activate-ncs-toolchain.sh
+++ b/scripts/activate-ncs-toolchain.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Activate the nRF Connect SDK toolchain environment for NCS v2.5.2.
+# Source this script from your shell:
+#   source scripts/activate-ncs-toolchain.sh
+
+NCS_VERSION="${NCS_VERSION:-v2.5.2}"
+TOOLCHAIN_PATH="${TOOLCHAIN_PATH:-$HOME/ncs/toolchains/7795df4459}"
+NRFUTIL_SDK_MANAGER="${NRFUTIL_SDK_MANAGER:-$HOME/.vscode/extensions/nordic-semiconductor.nrf-connect-2026.1.1327-linux-x64/platform/nrfutil/bin/nrfutil-sdk-manager}"
+
+if [[ ! -x "${NRFUTIL_SDK_MANAGER}" ]]; then
+  echo "nrfutil-sdk-manager not found: ${NRFUTIL_SDK_MANAGER}" >&2
+  echo "Set NRFUTIL_SDK_MANAGER to your installed extension path." >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+if [[ ! -d "${TOOLCHAIN_PATH}" ]]; then
+  echo "Toolchain path not found: ${TOOLCHAIN_PATH}" >&2
+  echo "Set TOOLCHAIN_PATH to your installed nRF toolchain directory." >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+if ! env_script="$("${NRFUTIL_SDK_MANAGER}" toolchain env --toolchain-path "${TOOLCHAIN_PATH}" --as-script sh 2>/dev/null)"; then
+  # Fallback for restricted environments where HOME is not writable.
+  env_script="$(HOME=/tmp "${NRFUTIL_SDK_MANAGER}" toolchain env --toolchain-path "${TOOLCHAIN_PATH}" --as-script sh)"
+fi
+
+set +u
+eval "${env_script}"
+set -u
+export NCS_TOOLCHAIN_VERSION="NONE"
+export NCS_VERSION
+
+echo "Activated nRF toolchain from: ${TOOLCHAIN_PATH}"
+echo "python: $(command -v python3)"
+echo "west:   $(command -v west)"

--- a/src/sensor_logic.c
+++ b/src/sensor_logic.c
@@ -24,6 +24,27 @@ unsigned int battery_level_pptt(unsigned int batt_mV, const struct battery_level
 	return pb->lvl_pptt + ((pa->lvl_pptt - pb->lvl_pptt) * (batt_mV - pb->lvl_mV) / (pa->lvl_mV - pb->lvl_mV));
 }
 
+uint16_t compute_battery_sleep_cycles(uint32_t battery_interval_seconds, uint32_t sleep_interval_seconds)
+{
+	if (sleep_interval_seconds == 0U)
+	{
+		return 1U;
+	}
+
+	uint32_t cycles = battery_interval_seconds / sleep_interval_seconds;
+	if (cycles == 0U)
+	{
+		return 1U;
+	}
+
+	if (cycles > UINT16_MAX)
+	{
+		return UINT16_MAX;
+	}
+
+	return (uint16_t)cycles;
+}
+
 uint16_t co2_ppm_to_attr_u16(double ppm, uint16_t max_value)
 {
 	if (ppm < 0.0)

--- a/src/sensor_logic.c
+++ b/src/sensor_logic.c
@@ -1,0 +1,40 @@
+#include "sensor_logic.h"
+
+unsigned int battery_level_pptt(unsigned int batt_mV, const struct battery_level_point *curve)
+{
+	const struct battery_level_point *pb = curve;
+
+	if (batt_mV >= pb->lvl_mV)
+	{
+		return pb->lvl_pptt;
+	}
+
+	while ((pb->lvl_pptt > 0) && (batt_mV < pb->lvl_mV))
+	{
+		++pb;
+	}
+
+	if (batt_mV < pb->lvl_mV)
+	{
+		return pb->lvl_pptt;
+	}
+
+	const struct battery_level_point *pa = pb - 1;
+
+	return pb->lvl_pptt + ((pa->lvl_pptt - pb->lvl_pptt) * (batt_mV - pb->lvl_mV) / (pa->lvl_mV - pb->lvl_mV));
+}
+
+uint16_t co2_ppm_to_attr_u16(double ppm, uint16_t max_value)
+{
+	if (ppm < 0.0)
+	{
+		return 0;
+	}
+
+	if (ppm > max_value)
+	{
+		return max_value;
+	}
+
+	return (uint16_t)ppm;
+}

--- a/src/sensor_logic.c
+++ b/src/sensor_logic.c
@@ -59,3 +59,24 @@ uint16_t co2_ppm_to_attr_u16(double ppm, uint16_t max_value)
 
 	return (uint16_t)ppm;
 }
+
+void commissioning_on_skip_startup(struct commissioning_state *state)
+{
+	state->stack_initialised = true;
+	state->joining_signal_received = false;
+}
+
+void commissioning_on_steering_result(struct commissioning_state *state, bool success)
+{
+	state->joining_signal_received = success;
+}
+
+void commissioning_on_leave(struct commissioning_state *state)
+{
+	state->joining_signal_received = false;
+}
+
+bool commissioning_should_reset_on_parent_link_failure(const struct commissioning_state *state)
+{
+	return state->stack_initialised && !state->joining_signal_received;
+}

--- a/src/zcl/zb_zcl_concentration_measurement.c
+++ b/src/zcl/zb_zcl_concentration_measurement.c
@@ -74,7 +74,7 @@ zb_ret_t check_value_concentration_measurement_server(zb_uint16_t attr_id, zb_ui
   switch( attr_id )
   {
     case ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_VALUE_ID:
-      if( ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_VALUE_UNKNOWN == ZB_ZCL_ATTR_GET32(value) )
+      if( ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_VALUE_UNKNOWN == ZB_ZCL_ATTR_GET16(value) )
       {
         ret = RET_OK;
       }
@@ -88,12 +88,12 @@ zb_ret_t check_value_concentration_measurement_server(zb_uint16_t attr_id, zb_ui
 
         ZB_ASSERT(attr_desc);
 
-        ret = (ZB_ZCL_GET_ATTRIBUTE_VAL_32(attr_desc) ==
+        ret = (ZB_ZCL_GET_ATTRIBUTE_VAL_16(attr_desc) ==
                 ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MIN_VALUE_UNDEFINED
-            || ZB_ZCL_GET_ATTRIBUTE_VAL_32(attr_desc) <= ZB_ZCL_ATTR_GET32(value))
+            || ZB_ZCL_GET_ATTRIBUTE_VAL_16(attr_desc) <= ZB_ZCL_ATTR_GET16(value))
           ? RET_OK : RET_ERROR;
 
-        if(ret)
+        if(ret == RET_OK)
         {
           attr_desc = zb_zcl_get_attr_desc_a(
               endpoint,
@@ -103,8 +103,8 @@ zb_ret_t check_value_concentration_measurement_server(zb_uint16_t attr_id, zb_ui
 
           ZB_ASSERT(attr_desc);
 
-          ret = ZB_ZCL_GET_ATTRIBUTE_VAL_32(attr_desc) == ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_UNDEFINED ||
-                ZB_ZCL_ATTR_GET32(value) <= ZB_ZCL_GET_ATTRIBUTE_VAL_32(attr_desc)
+          ret = ZB_ZCL_GET_ATTRIBUTE_VAL_16(attr_desc) == ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_UNDEFINED ||
+                ZB_ZCL_ATTR_GET16(value) <= ZB_ZCL_GET_ATTRIBUTE_VAL_16(attr_desc)
             ? RET_OK : RET_ERROR;
         }
       }
@@ -113,15 +113,15 @@ zb_ret_t check_value_concentration_measurement_server(zb_uint16_t attr_id, zb_ui
     case ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MIN_VALUE_ID:
       ret = (
 #if ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MIN_VALUE_MIN_VALUE != 0
-          ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MIN_VALUE_MIN_VALUE <= ZB_ZCL_ATTR_GET32(value) &&
+          ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MIN_VALUE_MIN_VALUE <= ZB_ZCL_ATTR_GET16(value) &&
 #endif
-              (ZB_ZCL_ATTR_GET32(value) <= ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MIN_VALUE_MAX_VALUE) )
+              (ZB_ZCL_ATTR_GET16(value) <= ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MIN_VALUE_MAX_VALUE) )
               ? RET_OK : RET_ERROR;
       break;
 
     case ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_ID:
-      ret = ( (ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_MIN_VALUE <= ZB_ZCL_ATTR_GET32(value)) &&
-              (ZB_ZCL_ATTR_GET32(value) <= ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_MAX_VALUE) )
+      ret = ( (ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_MIN_VALUE <= ZB_ZCL_ATTR_GET16(value)) &&
+              (ZB_ZCL_ATTR_GET16(value) <= ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_MAX_VALUE) )
               ? RET_OK : RET_ERROR;
       break;
 

--- a/src/zcl/zb_zcl_concentration_measurement.h
+++ b/src/zcl/zb_zcl_concentration_measurement.h
@@ -90,7 +90,7 @@ enum zb_zcl_concentration_measurement_attr_e
 #define ZB_ZCL_CONCENTRATION_MEASUREMENT_CLUSTER_REVISION_DEFAULT ((zb_uint16_t)0x0002u)
 
 /** @brief MeasuredValue attribute unknown value */
-#define ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_VALUE_UNKNOWN        ((zb_uint32_t)0xFFFF)
+#define ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_VALUE_UNKNOWN        ((zb_uint16_t)0xFFFF)
 
 /** @brief MinMeasuredValue attribute minimum value */
 #define ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MIN_VALUE_MIN_VALUE  0x0000
@@ -111,13 +111,13 @@ enum zb_zcl_concentration_measurement_attr_e
 #define ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_UNDEFINED  0xFFFF
 
 /** @brief Default value for MeasurementValue attribute */
-#define ZB_ZCL_CONCENTRATION_MEASUREMENT_VALUE_DEFAULT_VALUE ((zb_uint32_t)0xFFFF)
+#define ZB_ZCL_CONCENTRATION_MEASUREMENT_VALUE_DEFAULT_VALUE ((zb_uint16_t)0xFFFF)
 
 /** @brief Default value for MeasurementMinValue attribute */
-#define ZB_ZCL_CONCENTRATION_MEASUREMENT_MIN_VALUE_DEFAULT_VALUE ((zb_uint32_t)0xFFFF)
+#define ZB_ZCL_CONCENTRATION_MEASUREMENT_MIN_VALUE_DEFAULT_VALUE ((zb_uint16_t)0xFFFF)
 
 /** @brief Default value for MeasurementMaxValue attribute */
-#define ZB_ZCL_CONCENTRATION_MEASUREMENT_MAX_VALUE_DEFAULT_VALUE ((zb_uint32_t)0xFFFF)
+#define ZB_ZCL_CONCENTRATION_MEASUREMENT_MAX_VALUE_DEFAULT_VALUE ((zb_uint16_t)0xFFFF)
 
 /** @brief Tolerance attribute minimum value */
 #define ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_TOLERANCE_MIN_VALUE            0x0000
@@ -134,7 +134,7 @@ enum zb_zcl_concentration_measurement_attr_e
 #define ZB_SET_ATTR_DESCR_WITH_ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_VALUE_ID(data_ptr) \
 {                                                               \
   ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_VALUE_ID,                \
-  ZB_ZCL_ATTR_TYPE_SINGLE,                                         \
+  ZB_ZCL_ATTR_TYPE_U16,                                         \
   ZB_ZCL_ATTR_ACCESS_READ_ONLY | ZB_ZCL_ATTR_ACCESS_REPORTING,  \
   (void*) data_ptr                                         \
 }
@@ -142,7 +142,7 @@ enum zb_zcl_concentration_measurement_attr_e
 #define ZB_SET_ATTR_DESCR_WITH_ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MIN_VALUE_ID(data_ptr) \
 {                                                       \
   ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MIN_VALUE_ID,    \
-  ZB_ZCL_ATTR_TYPE_SINGLE,                                 \
+  ZB_ZCL_ATTR_TYPE_U16,                                 \
   ZB_ZCL_ATTR_ACCESS_READ_ONLY,                         \
   (void*) data_ptr                                 \
 }
@@ -150,7 +150,7 @@ enum zb_zcl_concentration_measurement_attr_e
 #define ZB_SET_ATTR_DESCR_WITH_ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_ID(data_ptr) \
 {                                                       \
   ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_ID,    \
-  ZB_ZCL_ATTR_TYPE_SINGLE,                                 \
+  ZB_ZCL_ATTR_TYPE_U16,                                 \
   ZB_ZCL_ATTR_ACCESS_READ_ONLY,                         \
   (void*) data_ptr                                 \
 }
@@ -158,7 +158,7 @@ enum zb_zcl_concentration_measurement_attr_e
 #define ZB_SET_ATTR_DESCR_WITH_ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_TOLERANCE_ID(data_ptr) \
 {                                                       \
   ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_TOLERANCE_ID,    \
-  ZB_ZCL_ATTR_TYPE_SINGLE,                                 \
+  ZB_ZCL_ATTR_TYPE_U16,                                 \
   ZB_ZCL_ATTR_ACCESS_READ_ONLY | ZB_ZCL_ATTR_ACCESS_REPORTING,                         \
   (void*) data_ptr                                 \
 }
@@ -177,7 +177,7 @@ enum zb_zcl_concentration_measurement_attr_e
 */
 #define ZB_ZCL_DECLARE_CONCENTRATION_MEASUREMENT_ATTRIB_LIST(attr_list,          \
     value, min_value, max_value, tolerance)                                                \
-  ZB_ZCL_START_DECLARE_ATTRIB_LIST_CLUSTER_REVISION(attr_list, ZB_ZCL_WATER_CONTENT_MEASUREMENT) \
+  ZB_ZCL_START_DECLARE_ATTRIB_LIST_CLUSTER_REVISION(attr_list, ZB_ZCL_CONCENTRATION_MEASUREMENT) \
   ZB_ZCL_SET_ATTR_DESC(ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_VALUE_ID, (value))          \
   ZB_ZCL_SET_ATTR_DESC(ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MIN_VALUE_ID, (min_value))  \
   ZB_ZCL_SET_ATTR_DESC(ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_ID, (max_value))  \

--- a/tests/logic/run_tests.sh
+++ b/tests/logic/run_tests.sh
@@ -6,7 +6,22 @@ BUILD_DIR="${TMPDIR:-/tmp}/schneggi-sensor-tests"
 
 mkdir -p "${BUILD_DIR}"
 
-cc -std=c11 -Wall -Wextra -Werror \
+CC_BIN="${CC:-}"
+if [[ -z "${CC_BIN}" ]]; then
+  for candidate in gcc clang cc; do
+    if command -v "${candidate}" >/dev/null 2>&1; then
+      CC_BIN="${candidate}"
+      break
+    fi
+  done
+fi
+
+if [[ -z "${CC_BIN}" ]]; then
+  echo "No suitable C compiler found (tried: \$CC, gcc, clang, cc)" >&2
+  exit 127
+fi
+
+"${CC_BIN}" -std=c11 -Wall -Wextra -Werror \
   -I"${ROOT_DIR}/include" \
   "${ROOT_DIR}/src/sensor_logic.c" \
   "${ROOT_DIR}/tests/logic/test_sensor_logic.c" \

--- a/tests/logic/run_tests.sh
+++ b/tests/logic/run_tests.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+BUILD_DIR="${TMPDIR:-/tmp}/schneggi-sensor-tests"
+
+mkdir -p "${BUILD_DIR}"
+
+cc -std=c11 -Wall -Wextra -Werror \
+  -I"${ROOT_DIR}/include" \
+  "${ROOT_DIR}/src/sensor_logic.c" \
+  "${ROOT_DIR}/tests/logic/test_sensor_logic.c" \
+  -o "${BUILD_DIR}/test_sensor_logic"
+
+"${BUILD_DIR}/test_sensor_logic"

--- a/tests/logic/test_sensor_logic.c
+++ b/tests/logic/test_sensor_logic.c
@@ -1,0 +1,49 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "sensor_logic.h"
+
+static void assert_u32_eq(uint32_t expected, uint32_t actual, const char *name)
+{
+	if (expected != actual)
+	{
+		fprintf(stderr, "FAIL: %s expected=%u actual=%u\n", name, expected, actual);
+		exit(1);
+	}
+}
+
+static void test_battery_level_pptt(void)
+{
+	static const struct battery_level_point curve[] = {
+		{10000, 4200},
+		{5000, 3700},
+		{0, 3200},
+	};
+
+	assert_u32_eq(10000, battery_level_pptt(4300, curve), "battery_above_max");
+	assert_u32_eq(10000, battery_level_pptt(4200, curve), "battery_at_max");
+	assert_u32_eq(0, battery_level_pptt(3000, curve), "battery_below_min");
+	assert_u32_eq(5000, battery_level_pptt(3700, curve), "battery_midpoint_exact");
+	assert_u32_eq(7500, battery_level_pptt(3950, curve), "battery_interpolate_upper");
+	assert_u32_eq(2500, battery_level_pptt(3450, curve), "battery_interpolate_lower");
+}
+
+static void test_co2_ppm_to_attr_u16(void)
+{
+	const uint16_t max_val = 10000;
+
+	assert_u32_eq(0, co2_ppm_to_attr_u16(-1.0, max_val), "co2_negative_clamped");
+	assert_u32_eq(0, co2_ppm_to_attr_u16(0.0, max_val), "co2_zero");
+	assert_u32_eq(412, co2_ppm_to_attr_u16(412.9, max_val), "co2_truncate_fraction");
+	assert_u32_eq(10000, co2_ppm_to_attr_u16(10000.0, max_val), "co2_at_max");
+	assert_u32_eq(10000, co2_ppm_to_attr_u16(10000.1, max_val), "co2_above_max_clamped");
+}
+
+int main(void)
+{
+	test_battery_level_pptt();
+	test_co2_ppm_to_attr_u16();
+	printf("All sensor_logic tests passed.\n");
+	return 0;
+}

--- a/tests/logic/test_sensor_logic.c
+++ b/tests/logic/test_sensor_logic.c
@@ -13,20 +13,74 @@ static void assert_u32_eq(uint32_t expected, uint32_t actual, const char *name)
 	}
 }
 
-static void test_battery_level_pptt(void)
+static void assert_true(int cond, const char *name)
 {
-	static const struct battery_level_point curve[] = {
+	if (!cond)
+	{
+		fprintf(stderr, "FAIL: %s\n", name);
+		exit(1);
+	}
+}
+
+static const struct battery_level_point full_curve[] = {
+	{10000, 4200},
+	{9500, 4150},
+	{9000, 4110},
+	{8500, 4080},
+	{8000, 4020},
+	{7500, 3980},
+	{7000, 3950},
+	{6500, 3910},
+	{6000, 3870},
+	{5500, 3850},
+	{5000, 3840},
+	{4500, 3820},
+	{4000, 3800},
+	{3500, 3790},
+	{3000, 3770},
+	{2500, 3750},
+	{2000, 3730},
+	{1500, 3710},
+	{1000, 3690},
+	{500, 3610},
+	{0, 3270},
+};
+
+static void test_battery_level_pptt_interpolation(void)
+{
+	static const struct battery_level_point simple_curve[] = {
 		{10000, 4200},
 		{5000, 3700},
 		{0, 3200},
 	};
 
-	assert_u32_eq(10000, battery_level_pptt(4300, curve), "battery_above_max");
-	assert_u32_eq(10000, battery_level_pptt(4200, curve), "battery_at_max");
-	assert_u32_eq(0, battery_level_pptt(3000, curve), "battery_below_min");
-	assert_u32_eq(5000, battery_level_pptt(3700, curve), "battery_midpoint_exact");
-	assert_u32_eq(7500, battery_level_pptt(3950, curve), "battery_interpolate_upper");
-	assert_u32_eq(2500, battery_level_pptt(3450, curve), "battery_interpolate_lower");
+	assert_u32_eq(10000, battery_level_pptt(4300, simple_curve), "battery_above_max");
+	assert_u32_eq(10000, battery_level_pptt(4200, simple_curve), "battery_at_max");
+	assert_u32_eq(0, battery_level_pptt(3000, simple_curve), "battery_below_min");
+	assert_u32_eq(5000, battery_level_pptt(3700, simple_curve), "battery_midpoint_exact");
+	assert_u32_eq(7500, battery_level_pptt(3950, simple_curve), "battery_interpolate_upper");
+	assert_u32_eq(2500, battery_level_pptt(3450, simple_curve), "battery_interpolate_lower");
+}
+
+static void test_battery_level_pptt_exact_curve_points(void)
+{
+	for (size_t i = 0; i < sizeof(full_curve) / sizeof(full_curve[0]); i++)
+	{
+		char name[64];
+		snprintf(name, sizeof(name), "battery_exact_point_%zu", i);
+		assert_u32_eq(full_curve[i].lvl_pptt, battery_level_pptt(full_curve[i].lvl_mV, full_curve), name);
+	}
+}
+
+static void test_battery_level_pptt_monotonicity(void)
+{
+	uint32_t last = 10001;
+	for (int mv = 4200; mv >= 3200; mv -= 10)
+	{
+		uint32_t current = battery_level_pptt((uint32_t)mv, full_curve);
+		assert_true(current <= last, "battery_monotonic_nonincreasing");
+		last = current;
+	}
 }
 
 static void test_co2_ppm_to_attr_u16(void)
@@ -34,16 +88,32 @@ static void test_co2_ppm_to_attr_u16(void)
 	const uint16_t max_val = 10000;
 
 	assert_u32_eq(0, co2_ppm_to_attr_u16(-1.0, max_val), "co2_negative_clamped");
+	assert_u32_eq(0, co2_ppm_to_attr_u16(-0.01, max_val), "co2_negative_tiny_clamped");
 	assert_u32_eq(0, co2_ppm_to_attr_u16(0.0, max_val), "co2_zero");
+	assert_u32_eq(0, co2_ppm_to_attr_u16(0.99, max_val), "co2_sub_one_truncates_zero");
 	assert_u32_eq(412, co2_ppm_to_attr_u16(412.9, max_val), "co2_truncate_fraction");
+	assert_u32_eq(9999, co2_ppm_to_attr_u16(9999.99, max_val), "co2_below_max_fraction");
 	assert_u32_eq(10000, co2_ppm_to_attr_u16(10000.0, max_val), "co2_at_max");
+	assert_u32_eq(10000, co2_ppm_to_attr_u16(10000.01, max_val), "co2_above_max_tiny_clamped");
 	assert_u32_eq(10000, co2_ppm_to_attr_u16(10000.1, max_val), "co2_above_max_clamped");
+}
+
+static void test_compute_battery_sleep_cycles(void)
+{
+	assert_u32_eq(48, compute_battery_sleep_cycles(4U * 60U * 60U, 5U * 60U), "cycles_normal_ratio");
+	assert_u32_eq(1, compute_battery_sleep_cycles(3599U, 3600U), "cycles_floor_to_minimum");
+	assert_u32_eq(1, compute_battery_sleep_cycles(3600U, 0U), "cycles_zero_sleep_guard");
+	assert_u32_eq(2, compute_battery_sleep_cycles(600U, 300U), "cycles_exact_divisible");
+	assert_u32_eq(2, compute_battery_sleep_cycles(601U, 300U), "cycles_non_divisible_floor");
 }
 
 int main(void)
 {
-	test_battery_level_pptt();
+	test_battery_level_pptt_interpolation();
+	test_battery_level_pptt_exact_curve_points();
+	test_battery_level_pptt_monotonicity();
 	test_co2_ppm_to_attr_u16();
+	test_compute_battery_sleep_cycles();
 	printf("All sensor_logic tests passed.\n");
 	return 0;
 }


### PR DESCRIPTION
## Summary
This PR improves runtime safety and test coverage for the Zigbee sensor firmware.

### Firmware fixes
- fix concentration measurement cluster typing mismatch and align storage/access to `u16`
- fix concentration range validation logic in custom ZCL handler
- fix wrong cluster revision declaration token for concentration cluster
- add missing `ram_pwrdn.h` include for `power_down_unused_ram()`
- guard SHTC3/SCD4X reads when device init/readiness fails
- handle SHTC3/SCD4X fetch failures before channel reads
- ensure battery monitor GPIO is always disabled on early-exit paths
- add return-code checks for GPIO operations and post-join sensor-loop scheduling
- make ADC init return errors and fail fast in `main()` when init/config fails
- harden commissioning/rejoin state transitions and parent-link-failure reset gating

### Logic extraction
- add shared pure logic module:
  - `battery_level_pptt(...)`
  - `co2_ppm_to_attr_u16(...)`
  - `compute_battery_sleep_cycles(...)`
  - commissioning state transition helpers
- use `compute_battery_sleep_cycles(...)` in firmware startup to derive report cadence safely

### Tests (host-side)
- add lightweight logic test runner (`tests/logic/run_tests.sh`)
- add unit tests for:
  - battery interpolation and boundaries
  - battery exact-curve-point regression
  - battery monotonicity across voltage sweep
  - CO2 conversion and near-boundary clamping/truncation
  - battery sleep-cycle math
  - commissioning state transitions (startup, steering success/failure, leave, parent-link-failure reset rule)

### CI
- run host logic tests in GitHub Actions before firmware build
- install host compiler (`gcc`) in workflow for logic test job
- enable `CONFIGURE_DEPENDS` for source glob so new `src/*.c` files are included without manual CMake edits

## Validation
- host logic tests pass: `./tests/logic/run_tests.sh`
- firmware builds successfully (local NCS v2.5.2):
  - `cmake --build build_debug -j4`
  - `zephyr/merged.hex` generated
