### PR TITLE
Fix Zigbee lifecycle handling; add tests/CI and sensor fallback

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,12 +23,15 @@ jobs:
           west init -l sensor
           west update -o=--depth=1 -n
 
-      - name: Run unit tests
-        working-directory: sensor/tests/unit/zigbee_signal_logic
+      - name: Install host compiler for unit tests
         run: |
-          cmake -S . -B build
-          cmake --build build
-          ctest --test-dir build --output-on-failure
+          apt-get update
+          apt-get install -y --no-install-recommends gcc libc6-dev
+
+      - name: Run unit tests
+        working-directory: sensor
+        run: |
+          ./tests/unit/zigbee_signal_logic/run_tests.sh
 
       - name: Build debug release
         working-directory: sensor

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: Build debug and release
 on:
   push:
+  pull_request:
 
 jobs:
   build-and-test-in-docker:
@@ -21,6 +22,13 @@ jobs:
         run: |
           west init -l sensor
           west update -o=--depth=1 -n
+
+      - name: Run unit tests
+        working-directory: sensor/tests/unit/zigbee_signal_logic
+        run: |
+          cmake -S . -B build
+          cmake --build build
+          ctest --test-dir build --output-on-failure
 
       - name: Build debug release
         working-directory: sensor

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-and-test-in-docker:
     runs-on: ubuntu-22.04
-    container: ghcr.io/nrfconnect/sdk-nrf-toolchain:v2.6.99
+    container: ghcr.io/nrfconnect/sdk-nrf-toolchain:v2.5.2
     defaults:
       run:
         # Bash shell is needed to set toolchain related environment variables in docker container

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-and-test-in-docker:
     runs-on: ubuntu-22.04
-    container: ghcr.io/nrfconnect/sdk-nrf-toolchain:v2.5.0
+    container: ghcr.io/nrfconnect/sdk-nrf-toolchain:v2.6.99
     defaults:
       run:
         # Bash shell is needed to set toolchain related environment variables in docker container

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-and-test-in-docker:
     runs-on: ubuntu-22.04
-    container: ghcr.io/nrfconnect/sdk-nrf-toolchain:v2.5.2
+    container: ghcr.io/nrfconnect/sdk-nrf-toolchain:v2.5.0
     defaults:
       run:
         # Bash shell is needed to set toolchain related environment variables in docker container

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Local editor settings
+.vscode/
+
+# Local build outputs
+build/
+
+# KiCad temporary lock files
+*.kicad_sch.lck
+
+# Local KiCad backup archives/directories
+*-backups/

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,6 @@ erase:
 	@$(NRFJPROG) -f NRF52 --snr $(SNR) --eraseall
 
 flash:
-	@$(NRFJPROG) -f NRF52 --snr $(SNR) --program $(HEX) --verify --reset
+	@$(NRFJPROG) -f NRF52 --snr $(SNR) --sectorerase --program $(HEX) --verify --reset
 
 erase-and-flash: erase flash

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,56 @@
+TOOLCHAIN_PATH ?= /home/michael/ncs/toolchains/7795df4459
+BUILD_DIR ?= build
+BOARD ?= adafruit_feather_nrf52840
+CONF_FILE ?= prj_debug.conf
+OVERLAY ?= boards/adafruit_feather_nrf52840.overlay
+SNR ?= 1050218947
+HEX ?= $(BUILD_DIR)/zephyr/merged.hex
+
+WEST ?= west
+NRFJPROG ?= nrfjprog
+
+WEST_ENV = \
+	PATH="$(TOOLCHAIN_PATH)/bin:$(TOOLCHAIN_PATH)/usr/bin:$(TOOLCHAIN_PATH)/usr/local/bin:$(TOOLCHAIN_PATH)/opt/bin:$(TOOLCHAIN_PATH)/opt/nanopb/generator-bin:$(TOOLCHAIN_PATH)/opt/zephyr-sdk/aarch64-zephyr-elf/bin:$(TOOLCHAIN_PATH)/opt/zephyr-sdk/x86_64-zephyr-elf/bin:$(TOOLCHAIN_PATH)/opt/zephyr-sdk/arm-zephyr-eabi/bin:$$PATH" \
+	LD_LIBRARY_PATH="$(TOOLCHAIN_PATH)/lib:$(TOOLCHAIN_PATH)/lib/x86_64-linux-gnu:$(TOOLCHAIN_PATH)/usr/local/lib:$${LD_LIBRARY_PATH:-}" \
+	GIT_EXEC_PATH="$(TOOLCHAIN_PATH)/usr/local/libexec/git-core" \
+	GIT_TEMPLATE_DIR="$(TOOLCHAIN_PATH)/usr/local/share/git-core/templates" \
+	PYTHONHOME="$(TOOLCHAIN_PATH)/usr/local" \
+	PYTHONPATH="$(TOOLCHAIN_PATH)/usr/local/lib/python3.8:$(TOOLCHAIN_PATH)/usr/local/lib/python3.8/site-packages" \
+	ZEPHYR_TOOLCHAIN_VARIANT=zephyr \
+	ZEPHYR_SDK_INSTALL_DIR="$(TOOLCHAIN_PATH)/opt/zephyr-sdk" \
+	CCACHE_DISABLE=1
+
+.PHONY: help build clean erase flash erase-and-flash
+
+help:
+	@echo "Targets:"
+	@echo "  make build            Build firmware into $(BUILD_DIR)"
+	@echo "  make clean            Pristine-clean $(BUILD_DIR)"
+	@echo "  make erase            Erase chip (clears Zigbee NVRAM)"
+	@echo "  make flash            Flash $(HEX)"
+	@echo "  make erase-and-flash  Erase, then flash"
+	@echo ""
+	@echo "Overrides:"
+	@echo "  SNR=<jlink_serial> BUILD_DIR=<dir> CONF_FILE=<file> OVERLAY=<file>"
+
+build:
+	@env $(WEST_ENV) $(WEST) build -d $(BUILD_DIR) -b $(BOARD) -- \
+		-DNCS_TOOLCHAIN_VERSION=NONE \
+		-DWEST_PYTHON="$(TOOLCHAIN_PATH)/usr/local/bin/python3.8" \
+		-DCONF_FILE="$(CONF_FILE)" \
+		-DDTC_OVERLAY_FILE="$(OVERLAY)"
+
+clean:
+	@if [ -d "$(BUILD_DIR)" ]; then \
+		env $(WEST_ENV) $(WEST) build -d $(BUILD_DIR) -t pristine; \
+	else \
+		echo "$(BUILD_DIR) does not exist, nothing to clean."; \
+	fi
+
+erase:
+	@$(NRFJPROG) -f NRF52 --snr $(SNR) --eraseall
+
+flash:
+	@$(NRFJPROG) -f NRF52 --snr $(SNR) --program $(HEX) --verify --reset
+
+erase-and-flash: erase flash

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,12 @@ WEST_ENV = \
 	ZEPHYR_SDK_INSTALL_DIR="$(TOOLCHAIN_PATH)/opt/zephyr-sdk" \
 	CCACHE_DISABLE=1
 
-.PHONY: help build clean erase flash erase-and-flash
+.PHONY: help build test clean erase flash erase-and-flash
 
 help:
 	@echo "Targets:"
 	@echo "  make build            Build firmware into $(BUILD_DIR)"
+	@echo "  make test             Run host unit tests"
 	@echo "  make clean            Pristine-clean $(BUILD_DIR)"
 	@echo "  make erase            Erase chip (clears Zigbee NVRAM)"
 	@echo "  make flash            Flash $(HEX)"
@@ -39,6 +40,11 @@ build:
 		-DWEST_PYTHON="$(TOOLCHAIN_PATH)/usr/local/bin/python3.8" \
 		-DCONF_FILE="$(CONF_FILE)" \
 		-DDTC_OVERLAY_FILE="$(OVERLAY)"
+
+test:
+	@cmake -S tests/unit/zigbee_signal_logic -B tests/unit/zigbee_signal_logic/build
+	@cmake --build tests/unit/zigbee_signal_logic/build
+	@ctest --test-dir tests/unit/zigbee_signal_logic/build --output-on-failure
 
 clean:
 	@if [ -d "$(BUILD_DIR)" ]; then \

--- a/include/zigbee_signal_logic.h
+++ b/include/zigbee_signal_logic.h
@@ -1,0 +1,49 @@
+#ifndef ZIGBEE_SIGNAL_LOGIC_H_
+#define ZIGBEE_SIGNAL_LOGIC_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+enum app_zigbee_signal {
+	APP_ZIGBEE_SIGNAL_SKIP_STARTUP,
+	APP_ZIGBEE_SIGNAL_DEVICE_FIRST_START,
+	APP_ZIGBEE_SIGNAL_DEVICE_REBOOT,
+	APP_ZIGBEE_SIGNAL_STEERING,
+	APP_ZIGBEE_SIGNAL_LEAVE,
+	APP_ZIGBEE_SIGNAL_CAN_SLEEP,
+	APP_ZIGBEE_SIGNAL_NLME_STATUS_INDICATION,
+	APP_ZIGBEE_SIGNAL_OTHER,
+};
+
+enum app_commissioning_mode {
+	APP_COMMISSIONING_NONE,
+	APP_COMMISSIONING_INITIALIZATION,
+	APP_COMMISSIONING_NETWORK_STEERING,
+};
+
+struct app_zigbee_state {
+	bool joining_signal_received;
+	bool stack_initialised;
+};
+
+struct app_zigbee_actions {
+	enum app_commissioning_mode commissioning_mode;
+	bool schedule_sensor_loop_cancel;
+	bool schedule_sensor_loop;
+	uint32_t schedule_sensor_loop_delay_ms;
+	bool set_long_poll_interval;
+	uint32_t long_poll_interval_ms;
+	bool request_sleep;
+	bool request_reset;
+};
+
+void app_zigbee_actions_reset(struct app_zigbee_actions *actions);
+
+void app_zigbee_handle_signal(struct app_zigbee_state *state,
+			      enum app_zigbee_signal signal,
+			      bool status_ok,
+			      bool leave_type_rejoin,
+			      bool parent_link_failure,
+			      struct app_zigbee_actions *actions);
+
+#endif /* ZIGBEE_SIGNAL_LOGIC_H_ */

--- a/src/main.c
+++ b/src/main.c
@@ -742,6 +742,14 @@ void zboss_signal_handler(zb_uint8_t param)
 
 	case ZB_BDB_SIGNAL_DEVICE_REBOOT:
 		LOG_DBG("> DEVICE_REBOOT");
+		if (status_ok)
+		{
+			LOG_INF("Joined network successfully on reboot.");
+		}
+		else
+		{
+			LOG_WRN("Reboot rejoin failed. Status: %d", status);
+		}
 		app_zigbee_handle_signal(&app_state,
 								 APP_ZIGBEE_SIGNAL_DEVICE_REBOOT,
 								 status_ok,

--- a/src/main.c
+++ b/src/main.c
@@ -680,19 +680,24 @@ void zboss_signal_handler(zb_uint8_t param)
 
 	case ZB_BDB_SIGNAL_DEVICE_FIRST_START:
 		LOG_DBG("> DEVICE_FIRST_START");
-		/* fall-through */
+		/* fall-through: (re)start steering below */
 
 	case ZB_BDB_SIGNAL_DEVICE_REBOOT:
 		LOG_DBG("> DEVICE_REBOOT");
-		/* fall-through */
+		joining_signal_received = false;
+		comm_status = bdb_start_top_level_commissioning(ZB_BDB_NETWORK_STEERING);
+		if (comm_status != ZB_TRUE)
+		{
+			LOG_WRN("Commissioning error");
+		}
+		break;
 
 	case ZB_BDB_SIGNAL_STEERING:
 		LOG_DBG("> STEERING");
 
-		joining_signal_received = true;
-
 		if (status == RET_OK)
 		{
+			joining_signal_received = true;
 			LOG_INF("Joined network successfully!");
 
 			/* timeout for receiving data from sensor and voltage from battery */
@@ -705,6 +710,7 @@ void zboss_signal_handler(zb_uint8_t param)
 		}
 		else
 		{
+			joining_signal_received = false;
 			LOG_WRN("Failed to join network. Status: %d", status);
 
 			comm_status = bdb_start_top_level_commissioning(ZB_BDB_NETWORK_STEERING);

--- a/src/zigbee_signal_logic.c
+++ b/src/zigbee_signal_logic.c
@@ -29,9 +29,28 @@ void app_zigbee_handle_signal(struct app_zigbee_state *state,
 		break;
 
 	case APP_ZIGBEE_SIGNAL_DEVICE_FIRST_START:
-	case APP_ZIGBEE_SIGNAL_DEVICE_REBOOT:
 		state->joining_signal_received = false;
-		actions->commissioning_mode = APP_COMMISSIONING_NETWORK_STEERING;
+		if (status_ok)
+		{
+			actions->commissioning_mode = APP_COMMISSIONING_NETWORK_STEERING;
+		}
+		break;
+
+	case APP_ZIGBEE_SIGNAL_DEVICE_REBOOT:
+		if (status_ok)
+		{
+			state->joining_signal_received = true;
+			actions->schedule_sensor_loop_cancel = true;
+			actions->schedule_sensor_loop = true;
+			actions->schedule_sensor_loop_delay_ms = 1000U;
+			actions->set_long_poll_interval = true;
+			actions->long_poll_interval_ms = 60000U;
+		}
+		else
+		{
+			state->joining_signal_received = false;
+			actions->commissioning_mode = APP_COMMISSIONING_NETWORK_STEERING;
+		}
 		break;
 
 	case APP_ZIGBEE_SIGNAL_STEERING:

--- a/src/zigbee_signal_logic.c
+++ b/src/zigbee_signal_logic.c
@@ -1,0 +1,83 @@
+#include "zigbee_signal_logic.h"
+
+void app_zigbee_actions_reset(struct app_zigbee_actions *actions)
+{
+	actions->commissioning_mode = APP_COMMISSIONING_NONE;
+	actions->schedule_sensor_loop_cancel = false;
+	actions->schedule_sensor_loop = false;
+	actions->schedule_sensor_loop_delay_ms = 0U;
+	actions->set_long_poll_interval = false;
+	actions->long_poll_interval_ms = 0U;
+	actions->request_sleep = false;
+	actions->request_reset = false;
+}
+
+void app_zigbee_handle_signal(struct app_zigbee_state *state,
+			      enum app_zigbee_signal signal,
+			      bool status_ok,
+			      bool leave_type_rejoin,
+			      bool parent_link_failure,
+			      struct app_zigbee_actions *actions)
+{
+	app_zigbee_actions_reset(actions);
+
+	switch (signal)
+	{
+	case APP_ZIGBEE_SIGNAL_SKIP_STARTUP:
+		state->stack_initialised = true;
+		actions->commissioning_mode = APP_COMMISSIONING_INITIALIZATION;
+		break;
+
+	case APP_ZIGBEE_SIGNAL_DEVICE_FIRST_START:
+	case APP_ZIGBEE_SIGNAL_DEVICE_REBOOT:
+		state->joining_signal_received = false;
+		actions->commissioning_mode = APP_COMMISSIONING_NETWORK_STEERING;
+		break;
+
+	case APP_ZIGBEE_SIGNAL_STEERING:
+		if (status_ok)
+		{
+			state->joining_signal_received = true;
+			actions->schedule_sensor_loop_cancel = true;
+			actions->schedule_sensor_loop = true;
+			actions->schedule_sensor_loop_delay_ms = 1000U;
+			actions->set_long_poll_interval = true;
+			actions->long_poll_interval_ms = 60000U;
+		}
+		else
+		{
+			state->joining_signal_received = false;
+			actions->commissioning_mode = APP_COMMISSIONING_NETWORK_STEERING;
+		}
+		break;
+
+	case APP_ZIGBEE_SIGNAL_LEAVE:
+		if (status_ok)
+		{
+			if (leave_type_rejoin)
+			{
+				state->joining_signal_received = false;
+			}
+
+			actions->commissioning_mode = APP_COMMISSIONING_NETWORK_STEERING;
+		}
+		break;
+
+	case APP_ZIGBEE_SIGNAL_CAN_SLEEP:
+		actions->request_sleep = true;
+		break;
+
+	case APP_ZIGBEE_SIGNAL_NLME_STATUS_INDICATION:
+		if (parent_link_failure &&
+		    state->stack_initialised &&
+		    !state->joining_signal_received)
+		{
+			actions->request_reset = true;
+		}
+		break;
+
+	case APP_ZIGBEE_SIGNAL_OTHER:
+	default:
+		break;
+	}
+}

--- a/tests/unit/zigbee_signal_logic/CMakeLists.txt
+++ b/tests/unit/zigbee_signal_logic/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(zigbee_signal_logic_tests C)
+
+enable_testing()
+
+add_executable(zigbee_signal_logic_tests
+	test_signal_logic.c
+	../../../src/zigbee_signal_logic.c
+)
+
+target_include_directories(zigbee_signal_logic_tests PRIVATE
+	../../../include
+)
+
+target_compile_features(zigbee_signal_logic_tests PRIVATE c_std_99)
+
+add_test(NAME zigbee_signal_logic_tests COMMAND zigbee_signal_logic_tests)

--- a/tests/unit/zigbee_signal_logic/run_tests.sh
+++ b/tests/unit/zigbee_signal_logic/run_tests.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+BUILD_DIR="${TMPDIR:-/tmp}/schneggi-zigbee-signal-tests"
+
+mkdir -p "${BUILD_DIR}"
+
+CC_BIN="${CC:-}"
+if [[ -z "${CC_BIN}" ]]; then
+	for candidate in gcc clang cc; do
+		if command -v "${candidate}" >/dev/null 2>&1; then
+			CC_BIN="${candidate}"
+			break
+		fi
+	done
+fi
+
+if [[ -z "${CC_BIN}" ]]; then
+	echo "No suitable C compiler found (tried: \$CC, gcc, clang, cc)" >&2
+	exit 127
+fi
+
+"${CC_BIN}" -std=c11 -Wall -Wextra -Werror \
+	-I"${ROOT_DIR}/include" \
+	"${ROOT_DIR}/src/zigbee_signal_logic.c" \
+	"${ROOT_DIR}/tests/unit/zigbee_signal_logic/test_signal_logic.c" \
+	-o "${BUILD_DIR}/test_zigbee_signal_logic"
+
+"${BUILD_DIR}/test_zigbee_signal_logic"

--- a/tests/unit/zigbee_signal_logic/test_signal_logic.c
+++ b/tests/unit/zigbee_signal_logic/test_signal_logic.c
@@ -1,0 +1,118 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "zigbee_signal_logic.h"
+
+static void assert_no_connected_side_effects(const struct app_zigbee_actions *actions)
+{
+	assert(actions->schedule_sensor_loop_cancel == false);
+	assert(actions->schedule_sensor_loop == false);
+	assert(actions->set_long_poll_interval == false);
+}
+
+static void test_device_first_start_does_not_mark_joined(void)
+{
+	struct app_zigbee_state state = {
+		.joining_signal_received = true,
+		.stack_initialised = true,
+	};
+	struct app_zigbee_actions actions;
+
+	app_zigbee_handle_signal(&state, APP_ZIGBEE_SIGNAL_DEVICE_FIRST_START, true, false, false, &actions);
+
+	assert(state.joining_signal_received == false);
+	assert(actions.commissioning_mode == APP_COMMISSIONING_NETWORK_STEERING);
+	assert_no_connected_side_effects(&actions);
+}
+
+static void test_device_reboot_does_not_mark_joined(void)
+{
+	struct app_zigbee_state state = {
+		.joining_signal_received = true,
+		.stack_initialised = true,
+	};
+	struct app_zigbee_actions actions;
+
+	app_zigbee_handle_signal(&state, APP_ZIGBEE_SIGNAL_DEVICE_REBOOT, true, false, false, &actions);
+
+	assert(state.joining_signal_received == false);
+	assert(actions.commissioning_mode == APP_COMMISSIONING_NETWORK_STEERING);
+	assert_no_connected_side_effects(&actions);
+}
+
+static void test_steering_success_marks_connected_and_schedules_work(void)
+{
+	struct app_zigbee_state state = {
+		.joining_signal_received = false,
+		.stack_initialised = true,
+	};
+	struct app_zigbee_actions actions;
+
+	app_zigbee_handle_signal(&state, APP_ZIGBEE_SIGNAL_STEERING, true, false, false, &actions);
+
+	assert(state.joining_signal_received == true);
+	assert(actions.commissioning_mode == APP_COMMISSIONING_NONE);
+	assert(actions.schedule_sensor_loop_cancel == true);
+	assert(actions.schedule_sensor_loop == true);
+	assert(actions.schedule_sensor_loop_delay_ms == 1000U);
+	assert(actions.set_long_poll_interval == true);
+	assert(actions.long_poll_interval_ms == 60000U);
+}
+
+static void test_steering_failure_clears_connected_and_retries(void)
+{
+	struct app_zigbee_state state = {
+		.joining_signal_received = true,
+		.stack_initialised = true,
+	};
+	struct app_zigbee_actions actions;
+
+	app_zigbee_handle_signal(&state, APP_ZIGBEE_SIGNAL_STEERING, false, false, false, &actions);
+
+	assert(state.joining_signal_received == false);
+	assert(actions.commissioning_mode == APP_COMMISSIONING_NETWORK_STEERING);
+	assert_no_connected_side_effects(&actions);
+}
+
+static void test_startup_to_first_start_to_steering_only_sets_joined_on_steering(void)
+{
+	struct app_zigbee_state state = {
+		.joining_signal_received = false,
+		.stack_initialised = false,
+	};
+	struct app_zigbee_actions actions;
+
+	app_zigbee_handle_signal(&state, APP_ZIGBEE_SIGNAL_SKIP_STARTUP, true, false, false, &actions);
+	assert(state.stack_initialised == true);
+	assert(state.joining_signal_received == false);
+	assert(actions.commissioning_mode == APP_COMMISSIONING_INITIALIZATION);
+	assert_no_connected_side_effects(&actions);
+
+	app_zigbee_handle_signal(&state, APP_ZIGBEE_SIGNAL_DEVICE_FIRST_START, true, false, false, &actions);
+	assert(state.joining_signal_received == false);
+	assert(actions.commissioning_mode == APP_COMMISSIONING_NETWORK_STEERING);
+	assert_no_connected_side_effects(&actions);
+
+	app_zigbee_handle_signal(&state, APP_ZIGBEE_SIGNAL_STEERING, true, false, false, &actions);
+	assert(state.joining_signal_received == true);
+	assert(actions.schedule_sensor_loop == true);
+	assert(actions.set_long_poll_interval == true);
+
+	app_zigbee_handle_signal(&state, APP_ZIGBEE_SIGNAL_STEERING, false, false, false, &actions);
+	assert(state.joining_signal_received == false);
+	assert(actions.commissioning_mode == APP_COMMISSIONING_NETWORK_STEERING);
+	assert_no_connected_side_effects(&actions);
+}
+
+int main(void)
+{
+	test_device_first_start_does_not_mark_joined();
+	test_device_reboot_does_not_mark_joined();
+	test_steering_success_marks_connected_and_schedules_work();
+	test_steering_failure_clears_connected_and_retries();
+	test_startup_to_first_start_to_steering_only_sets_joined_on_steering();
+
+	printf("zigbee_signal_logic unit tests passed\n");
+	return 0;
+}

--- a/tests/unit/zigbee_signal_logic/test_signal_logic.c
+++ b/tests/unit/zigbee_signal_logic/test_signal_logic.c
@@ -26,7 +26,7 @@ static void test_device_first_start_does_not_mark_joined(void)
 	assert_no_connected_side_effects(&actions);
 }
 
-static void test_device_reboot_does_not_mark_joined(void)
+static void test_device_first_start_failure_does_not_start_commissioning(void)
 {
 	struct app_zigbee_state state = {
 		.joining_signal_received = true,
@@ -34,7 +34,41 @@ static void test_device_reboot_does_not_mark_joined(void)
 	};
 	struct app_zigbee_actions actions;
 
+	app_zigbee_handle_signal(&state, APP_ZIGBEE_SIGNAL_DEVICE_FIRST_START, false, false, false, &actions);
+
+	assert(state.joining_signal_received == false);
+	assert(actions.commissioning_mode == APP_COMMISSIONING_NONE);
+	assert_no_connected_side_effects(&actions);
+}
+
+static void test_device_reboot_success_marks_joined_and_does_not_restart_commissioning(void)
+{
+	struct app_zigbee_state state = {
+		.joining_signal_received = false,
+		.stack_initialised = true,
+	};
+	struct app_zigbee_actions actions;
+
 	app_zigbee_handle_signal(&state, APP_ZIGBEE_SIGNAL_DEVICE_REBOOT, true, false, false, &actions);
+
+	assert(state.joining_signal_received == true);
+	assert(actions.commissioning_mode == APP_COMMISSIONING_NONE);
+	assert(actions.schedule_sensor_loop_cancel == true);
+	assert(actions.schedule_sensor_loop == true);
+	assert(actions.schedule_sensor_loop_delay_ms == 1000U);
+	assert(actions.set_long_poll_interval == true);
+	assert(actions.long_poll_interval_ms == 60000U);
+}
+
+static void test_device_reboot_failure_restarts_commissioning(void)
+{
+	struct app_zigbee_state state = {
+		.joining_signal_received = true,
+		.stack_initialised = true,
+	};
+	struct app_zigbee_actions actions;
+
+	app_zigbee_handle_signal(&state, APP_ZIGBEE_SIGNAL_DEVICE_REBOOT, false, false, false, &actions);
 
 	assert(state.joining_signal_received == false);
 	assert(actions.commissioning_mode == APP_COMMISSIONING_NETWORK_STEERING);
@@ -108,7 +142,9 @@ static void test_startup_to_first_start_to_steering_only_sets_joined_on_steering
 int main(void)
 {
 	test_device_first_start_does_not_mark_joined();
-	test_device_reboot_does_not_mark_joined();
+	test_device_first_start_failure_does_not_start_commissioning();
+	test_device_reboot_success_marks_joined_and_does_not_restart_commissioning();
+	test_device_reboot_failure_restarts_commissioning();
 	test_steering_success_marks_connected_and_schedules_work();
 	test_steering_failure_clears_connected_and_retries();
 	test_startup_to_first_start_to_steering_only_sets_joined_on_steering();


### PR DESCRIPTION
## Summary
- Fix Zigbee lifecycle handling so join state changes happen on the correct ZBOSS signals.
- Add host unit tests for key Zigbee lifecycle scenarios and run them in GitHub CI.
- Add developer workflow helpers (`Makefile`, `.gitignore` updates).
- Improve runtime robustness when sensors are missing/unavailable by keeping last valid Zigbee attribute values.

## Key Changes
- `src/zigbee_signal_logic.c`, `include/zigbee_signal_logic.h`
  - Centralized, side-effect-free Zigbee signal state machine logic.
- `src/main.c`
  - Runtime executes actions produced by signal logic module.
  - Reboot path treated as connected when `DEVICE_REBOOT` is successful.
  - Sensor update path now keeps previous values if SHTC3/SCD4X are not ready or fetch/read fails.
- `tests/unit/zigbee_signal_logic/test_signal_logic.c`
- `tests/unit/zigbee_signal_logic/CMakeLists.txt`
- `tests/unit/zigbee_signal_logic/run_tests.sh`
  - Unit coverage for first start, reboot success/failure, steering success/failure, and startup lifecycle sequence.
- `.github/workflows/main.yml`
  - CI runs host unit tests.
- `Makefile`
  - Adds `build`, `test`, `clean`, `erase`, `flash` targets.
- `.gitignore`
  - Ignores local build/editor/KiCad artifacts.

## Validation
- `make test`
- `make build`
- Manual Zigbee join/interview verification with Home Assistant ZHA logs.
