### PR TITLE
Fix critical Zigbee sensor bugs and harden build workflow

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -2,6 +2,10 @@ source "Kconfig.zephyr"
 
 config SENSOR_UPDATE_INTERVAL_MINUTES
   int "Sensor update interval in minutes"
+  range 1 1440
+  default 5
 
 config BATTERY_UPDATE_INTERVAL_HOURS
   int "Battery update interval in hours"
+  range 1 720
+  default 4

--- a/src/main.c
+++ b/src/main.c
@@ -10,6 +10,7 @@
 #include <zephyr/settings/settings.h>
 #include <zephyr/sys/util.h>
 #include <dk_buttons_and_leds.h>
+#include <ram_pwrdn.h>
 
 #include <zboss_api.h>
 #include <zboss_api_addons.h>

--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,7 @@
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/settings/settings.h>
+#include <zephyr/sys/util.h>
 #include <dk_buttons_and_leds.h>
 
 #include <zboss_api.h>
@@ -29,6 +30,9 @@ static const uint16_t SLEEP_INTERVAL_SECONDS = CONFIG_SENSOR_UPDATE_INTERVAL_MIN
 static const uint16_t BATTERY_REPORT_INTERVAL_SECONDS = CONFIG_BATTERY_UPDATE_INTERVAL_HOURS * 60 * 60; // HA minimum = 3600s
 static const uint16_t BATTERY_SLEEP_CYCLES = BATTERY_REPORT_INTERVAL_SECONDS / SLEEP_INTERVAL_SECONDS;
 
+BUILD_ASSERT(CONFIG_SENSOR_UPDATE_INTERVAL_MINUTES > 0, "CONFIG_SENSOR_UPDATE_INTERVAL_MINUTES must be greater than zero");
+BUILD_ASSERT(CONFIG_BATTERY_UPDATE_INTERVAL_HOURS > 0, "CONFIG_BATTERY_UPDATE_INTERVAL_HOURS must be greater than zero");
+
 #define ENABLE_SCD
 
 // ZigBee
@@ -46,9 +50,9 @@ typedef struct
 
 typedef struct
 {
-	zb_int16_t measure_value;
-	zb_int16_t min_measure_value;
-	zb_int16_t max_measure_value;
+	zb_uint16_t measure_value;
+	zb_uint16_t min_measure_value;
+	zb_uint16_t max_measure_value;
 	zb_uint16_t tolerance;
 } zb_zcl_concentration_measurement_attrs_t;
 
@@ -303,7 +307,7 @@ static void init_clusters_attr(void)
 		ZB_ZCL_CONCENTRATION_MEASUREMENT_MIN_VALUE_DEFAULT_VALUE;
 	dev_ctx.concentration_measure_attrs.max_measure_value =
 		ZB_ZCL_CONCENTRATION_MEASUREMENT_MAX_VALUE_DEFAULT_VALUE; // 10 000ppm
-	dev_ctx.concentration_measure_attrs.tolerance = 0.0001f;	  // 100 ppm
+	dev_ctx.concentration_measure_attrs.tolerance = 100;		  // 100 ppm
 }
 
 /**@brief Function to toggle the identify LED
@@ -430,7 +434,7 @@ void update_sensor_values()
 		else
 		{
 			double measured_co2 = 0.0;
-			float co2_attribute = 0.0f;
+			zb_uint16_t co2_attribute = 0;
 			struct sensor_value sensor_value;
 
 			err = sensor_channel_get(scd, SENSOR_CHAN_CO2, &sensor_value);
@@ -443,8 +447,20 @@ void update_sensor_values()
 				measured_co2 = sensor_value_to_double(&sensor_value);
 				LOG_INF("CO2: %.2f ppm", measured_co2);
 
-				/* Convert measured value to attribute value, as specified in ZCL */
-				co2_attribute = measured_co2 * ZCL_CO2_MEASUREMENT_MEASURED_VALUE_MULTIPLIER;
+				if (measured_co2 < 0.0)
+				{
+					LOG_WRN("CO2 reading below zero, clamping to zero");
+					co2_attribute = 0;
+				}
+				else if (measured_co2 > ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_MAX_VALUE)
+				{
+					LOG_WRN("CO2 reading above maximum supported value, clamping");
+					co2_attribute = ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_MAX_VALUE;
+				}
+				else
+				{
+					co2_attribute = (zb_uint16_t)(measured_co2 + 0.5);
+				}
 
 				zb_zcl_status_t status =
 					zb_zcl_set_attr_val(SCHNEGGI_ENDPOINT,
@@ -596,7 +612,7 @@ void update_battery()
 				if (battery_voltage_mv < 0)
 				{
 					LOG_DBG("Not reporting negative voltage");
-					return;
+					goto cleanup;
 				}
 
 				uint8_t battery_attribute = (uint8_t)(battery_voltage_mv / 100);
@@ -611,7 +627,7 @@ void update_battery()
 				if (status_battery_voltage)
 				{
 					LOG_ERR("Failed to set ZCL attribute: %d", status_battery_voltage);
-					return;
+					goto cleanup;
 				}
 
 				uint32_t battery_percentage = battery_level_pptt(battery_voltage_mv, discharge_curve) / 100;
@@ -627,11 +643,12 @@ void update_battery()
 				if (status_battery_percentage)
 				{
 					LOG_ERR("Failed to set ZCL attribute: %d", status_battery_percentage);
-					return;
+					goto cleanup;
 				}
 			}
 		}
 	}
+cleanup:
 	// Disable battery measurement
 	gpio_pin_set_dt(&battery_monitor_enable, 0);
 }

--- a/src/zcl/zb_zcl_concentration_measurement.c
+++ b/src/zcl/zb_zcl_concentration_measurement.c
@@ -74,7 +74,7 @@ zb_ret_t check_value_concentration_measurement_server(zb_uint16_t attr_id, zb_ui
   switch( attr_id )
   {
     case ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_VALUE_ID:
-      if( ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_VALUE_UNKNOWN == ZB_ZCL_ATTR_GET32(value) )
+      if( ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_VALUE_UNKNOWN == ZB_ZCL_ATTR_GET16(value) )
       {
         ret = RET_OK;
       }
@@ -88,12 +88,12 @@ zb_ret_t check_value_concentration_measurement_server(zb_uint16_t attr_id, zb_ui
 
         ZB_ASSERT(attr_desc);
 
-        ret = (ZB_ZCL_GET_ATTRIBUTE_VAL_32(attr_desc) ==
+        ret = (ZB_ZCL_GET_ATTRIBUTE_VAL_16(attr_desc) ==
                 ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MIN_VALUE_UNDEFINED
-            || ZB_ZCL_GET_ATTRIBUTE_VAL_32(attr_desc) <= ZB_ZCL_ATTR_GET32(value))
+            || ZB_ZCL_GET_ATTRIBUTE_VAL_16(attr_desc) <= ZB_ZCL_ATTR_GET16(value))
           ? RET_OK : RET_ERROR;
 
-        if(ret)
+        if(ret == RET_OK)
         {
           attr_desc = zb_zcl_get_attr_desc_a(
               endpoint,
@@ -103,8 +103,8 @@ zb_ret_t check_value_concentration_measurement_server(zb_uint16_t attr_id, zb_ui
 
           ZB_ASSERT(attr_desc);
 
-          ret = ZB_ZCL_GET_ATTRIBUTE_VAL_32(attr_desc) == ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_UNDEFINED ||
-                ZB_ZCL_ATTR_GET32(value) <= ZB_ZCL_GET_ATTRIBUTE_VAL_32(attr_desc)
+          ret = ZB_ZCL_GET_ATTRIBUTE_VAL_16(attr_desc) == ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_UNDEFINED ||
+                ZB_ZCL_ATTR_GET16(value) <= ZB_ZCL_GET_ATTRIBUTE_VAL_16(attr_desc)
             ? RET_OK : RET_ERROR;
         }
       }
@@ -113,15 +113,15 @@ zb_ret_t check_value_concentration_measurement_server(zb_uint16_t attr_id, zb_ui
     case ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MIN_VALUE_ID:
       ret = (
 #if ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MIN_VALUE_MIN_VALUE != 0
-          ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MIN_VALUE_MIN_VALUE <= ZB_ZCL_ATTR_GET32(value) &&
+          ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MIN_VALUE_MIN_VALUE <= ZB_ZCL_ATTR_GET16(value) &&
 #endif
-              (ZB_ZCL_ATTR_GET32(value) <= ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MIN_VALUE_MAX_VALUE) )
+              (ZB_ZCL_ATTR_GET16(value) <= ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MIN_VALUE_MAX_VALUE) )
               ? RET_OK : RET_ERROR;
       break;
 
     case ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_ID:
-      ret = ( (ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_MIN_VALUE <= ZB_ZCL_ATTR_GET32(value)) &&
-              (ZB_ZCL_ATTR_GET32(value) <= ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_MAX_VALUE) )
+      ret = ( (ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_MIN_VALUE <= ZB_ZCL_ATTR_GET16(value)) &&
+              (ZB_ZCL_ATTR_GET16(value) <= ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_MAX_VALUE) )
               ? RET_OK : RET_ERROR;
       break;
 

--- a/src/zcl/zb_zcl_concentration_measurement.h
+++ b/src/zcl/zb_zcl_concentration_measurement.h
@@ -90,7 +90,7 @@ enum zb_zcl_concentration_measurement_attr_e
 #define ZB_ZCL_CONCENTRATION_MEASUREMENT_CLUSTER_REVISION_DEFAULT ((zb_uint16_t)0x0002u)
 
 /** @brief MeasuredValue attribute unknown value */
-#define ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_VALUE_UNKNOWN        ((zb_uint32_t)0xFFFF)
+#define ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_VALUE_UNKNOWN        ((zb_uint16_t)0xFFFF)
 
 /** @brief MinMeasuredValue attribute minimum value */
 #define ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MIN_VALUE_MIN_VALUE  0x0000
@@ -111,13 +111,13 @@ enum zb_zcl_concentration_measurement_attr_e
 #define ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_UNDEFINED  0xFFFF
 
 /** @brief Default value for MeasurementValue attribute */
-#define ZB_ZCL_CONCENTRATION_MEASUREMENT_VALUE_DEFAULT_VALUE ((zb_uint32_t)0xFFFF)
+#define ZB_ZCL_CONCENTRATION_MEASUREMENT_VALUE_DEFAULT_VALUE ((zb_uint16_t)0xFFFF)
 
 /** @brief Default value for MeasurementMinValue attribute */
-#define ZB_ZCL_CONCENTRATION_MEASUREMENT_MIN_VALUE_DEFAULT_VALUE ((zb_uint32_t)0xFFFF)
+#define ZB_ZCL_CONCENTRATION_MEASUREMENT_MIN_VALUE_DEFAULT_VALUE ((zb_uint16_t)0xFFFF)
 
 /** @brief Default value for MeasurementMaxValue attribute */
-#define ZB_ZCL_CONCENTRATION_MEASUREMENT_MAX_VALUE_DEFAULT_VALUE ((zb_uint32_t)0xFFFF)
+#define ZB_ZCL_CONCENTRATION_MEASUREMENT_MAX_VALUE_DEFAULT_VALUE ((zb_uint16_t)0xFFFF)
 
 /** @brief Tolerance attribute minimum value */
 #define ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_TOLERANCE_MIN_VALUE            0x0000
@@ -134,7 +134,7 @@ enum zb_zcl_concentration_measurement_attr_e
 #define ZB_SET_ATTR_DESCR_WITH_ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_VALUE_ID(data_ptr) \
 {                                                               \
   ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_VALUE_ID,                \
-  ZB_ZCL_ATTR_TYPE_SINGLE,                                         \
+  ZB_ZCL_ATTR_TYPE_U16,                                         \
   ZB_ZCL_ATTR_ACCESS_READ_ONLY | ZB_ZCL_ATTR_ACCESS_REPORTING,  \
   (void*) data_ptr                                         \
 }
@@ -142,7 +142,7 @@ enum zb_zcl_concentration_measurement_attr_e
 #define ZB_SET_ATTR_DESCR_WITH_ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MIN_VALUE_ID(data_ptr) \
 {                                                       \
   ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MIN_VALUE_ID,    \
-  ZB_ZCL_ATTR_TYPE_SINGLE,                                 \
+  ZB_ZCL_ATTR_TYPE_U16,                                 \
   ZB_ZCL_ATTR_ACCESS_READ_ONLY,                         \
   (void*) data_ptr                                 \
 }
@@ -150,7 +150,7 @@ enum zb_zcl_concentration_measurement_attr_e
 #define ZB_SET_ATTR_DESCR_WITH_ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_ID(data_ptr) \
 {                                                       \
   ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_ID,    \
-  ZB_ZCL_ATTR_TYPE_SINGLE,                                 \
+  ZB_ZCL_ATTR_TYPE_U16,                                 \
   ZB_ZCL_ATTR_ACCESS_READ_ONLY,                         \
   (void*) data_ptr                                 \
 }
@@ -158,7 +158,7 @@ enum zb_zcl_concentration_measurement_attr_e
 #define ZB_SET_ATTR_DESCR_WITH_ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_TOLERANCE_ID(data_ptr) \
 {                                                       \
   ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_TOLERANCE_ID,    \
-  ZB_ZCL_ATTR_TYPE_SINGLE,                                 \
+  ZB_ZCL_ATTR_TYPE_U16,                                 \
   ZB_ZCL_ATTR_ACCESS_READ_ONLY | ZB_ZCL_ATTR_ACCESS_REPORTING,                         \
   (void*) data_ptr                                 \
 }
@@ -177,7 +177,7 @@ enum zb_zcl_concentration_measurement_attr_e
 */
 #define ZB_ZCL_DECLARE_CONCENTRATION_MEASUREMENT_ATTRIB_LIST(attr_list,          \
     value, min_value, max_value, tolerance)                                                \
-  ZB_ZCL_START_DECLARE_ATTRIB_LIST_CLUSTER_REVISION(attr_list, ZB_ZCL_WATER_CONTENT_MEASUREMENT) \
+  ZB_ZCL_START_DECLARE_ATTRIB_LIST_CLUSTER_REVISION(attr_list, ZB_ZCL_CONCENTRATION_MEASUREMENT) \
   ZB_ZCL_SET_ATTR_DESC(ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_VALUE_ID, (value))          \
   ZB_ZCL_SET_ATTR_DESC(ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MIN_VALUE_ID, (min_value))  \
   ZB_ZCL_SET_ATTR_DESC(ZB_ZCL_ATTR_CONCENTRATION_MEASUREMENT_MAX_VALUE_ID, (max_value))  \


### PR DESCRIPTION
## Summary
- fix concentration measurement attribute type mismatches (U16 end-to-end) to eliminate potential memory corruption
- fix concentration min/max validation flow and 16-bit value checks in custom ZCL handler
- clamp CO2 values before writing ZCL attribute and align tolerance/default handling
- ensure battery monitor power GPIO is always disabled by routing early exits through cleanup
- enforce non-zero interval constraints in Kconfig and compile-time asserts in firmware
- harden Makefile with toolchain preflight checks and explicit toolchain python wiring

## Validation
- tests/unit/zigbee_signal_logic/run_tests.sh
- make check-toolchain
- make build (successful, generated build/zephyr/merged.hex)
