### PR TITLE
Make SCD4X optional and hide CO2 cluster when disabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ TOOLCHAIN_PYTHON ?= $(firstword $(wildcard $(TOOLCHAIN_PATH)/usr/local/bin/pytho
 # --- Build config ---
 BOARD ?= adafruit_feather_nrf52840
 CONF_FILE ?= prj_debug.conf
-OVERLAY ?= boards/adafruit_feather_nrf52840.overlay
+OVERLAY ?= boards/adafruit_feather_nrf52840.overlay;boards/no_scd4x.overlay
 BUILD_DIR ?= build_west
 APP_DIR := $(CURDIR)
 NCS_WORKSPACE ?= $(if $(wildcard $(APP_DIR)/../.west),$(abspath $(APP_DIR)/..),$(shell find $$HOME/ncs -mindepth 1 -maxdepth 1 -type d -name 'v*' 2>/dev/null | sort | tail -n1))
@@ -30,10 +30,10 @@ WEST_ENV = \
 	ZEPHYR_SDK_INSTALL_DIR="$(TOOLCHAIN_PATH)/opt/zephyr-sdk" \
 	CCACHE_DISABLE=1
 
-.PHONY: help check check-toolchain west-update build test clean erase flash erase-and-flash
+.PHONY: help check check-toolchain west-update build build-no-scd4x build-scd4x test clean erase flash erase-and-flash
 
 help:
-	@echo "Targets: west-update build test clean erase flash erase-and-flash"
+	@echo "Targets: west-update build build-no-scd4x build-scd4x test clean erase flash erase-and-flash"
 	@echo "Overrides: TOOLCHAIN_PATH TOOLCHAIN_PYTHON NCS_WORKSPACE BOARD CONF_FILE OVERLAY BUILD_DIR SNR"
 
 check:
@@ -54,6 +54,12 @@ build: check
 		-DWEST_PYTHON="$(TOOLCHAIN_PYTHON)" \
 		-DCONF_FILE="$(CONF_FILE)" \
 		-DDTC_OVERLAY_FILE="$(OVERLAY)"
+
+build-no-scd4x: OVERLAY=boards/adafruit_feather_nrf52840.overlay;boards/no_scd4x.overlay
+build-no-scd4x: build
+
+build-scd4x: OVERLAY=boards/adafruit_feather_nrf52840.overlay
+build-scd4x: build
 
 test:
 	@cmake -S tests/unit -B tests/unit/build

--- a/boards/no_scd4x.overlay
+++ b/boards/no_scd4x.overlay
@@ -1,0 +1,5 @@
+&i2c1 {
+	scd4x@62 {
+		status = "disabled";
+	};
+};

--- a/include/zb_dimmable_light.h
+++ b/include/zb_dimmable_light.h
@@ -2,12 +2,15 @@
 #define ZB_DEVICE_VERSION 1
 
 /** Number of Cluster attributes */
-#define ZB_DIMMABLE_LIGHT_IN_CLUSTER_NUM 6
+#define ZB_DIMMABLE_LIGHT_IN_CLUSTER_NUM_WITH_CO2 6
+#define ZB_DIMMABLE_LIGHT_IN_CLUSTER_NUM_NO_CO2 5
 #define ZB_DIMMABLE_LIGHT_OUT_CLUSTER_NUM 0
 
 /** Number of attribute for reporting */
-#define ZB_DIMMABLE_LIGHT_REPORT_ATTR_COUNT \
+#define ZB_DIMMABLE_LIGHT_REPORT_ATTR_COUNT_WITH_CO2 \
 	(ZB_ZCL_TEMP_MEASUREMENT_REPORT_ATTR_COUNT + ZB_ZCL_REL_HUMIDITY_MEASUREMENT_REPORT_ATTR_COUNT + ZB_ZCL_CONCENTRATION_MEASUREMENT_REPORT_ATTR_COUNT + ZB_ZCL_POWER_CONFIG_REPORT_ATTR_COUNT)
+#define ZB_DIMMABLE_LIGHT_REPORT_ATTR_COUNT_NO_CO2 \
+	(ZB_ZCL_TEMP_MEASUREMENT_REPORT_ATTR_COUNT + ZB_ZCL_REL_HUMIDITY_MEASUREMENT_REPORT_ATTR_COUNT + ZB_ZCL_POWER_CONFIG_REPORT_ATTR_COUNT)
 
 #define ZB_DECLARE_DIMMABLE_LIGHT_CLUSTER_LIST(                                  \
 	cluster_list_name,                                                           \
@@ -51,12 +54,71 @@
 				ZB_ZCL_MANUF_CODE_INVALID),                                          \
 			ZB_ZCL_CLUSTER_DESC(                                                 \
 				ZB_ZCL_CLUSTER_ID_POWER_CONFIG,                                  \
-				ZB_ZCL_ARRAY_SIZE(power_config_attr_list, zb_zcl_attr_t),        \
-				(power_config_attr_list),                                        \
-				ZB_ZCL_CLUSTER_SERVER_ROLE,                                      \
+					ZB_ZCL_ARRAY_SIZE(power_config_attr_list, zb_zcl_attr_t),        \
+					(power_config_attr_list),                                        \
+					ZB_ZCL_CLUSTER_SERVER_ROLE,                                      \
+					ZB_ZCL_MANUF_CODE_INVALID)}
+
+#define ZB_DECLARE_DIMMABLE_LIGHT_CLUSTER_LIST_NO_CO2(                               \
+	cluster_list_name,                                                                \
+	basic_attr_list,                                                                  \
+	identify_attr_list,                                                               \
+	temperature_measure_attr_list,                                                    \
+	humidity_measure_attr_list,                                                       \
+	power_config_attr_list)                                                           \
+	zb_zcl_cluster_desc_t cluster_list_name[] =                                       \
+		{                                                                             \
+			ZB_ZCL_CLUSTER_DESC(                                                      \
+				ZB_ZCL_CLUSTER_ID_IDENTIFY,                                           \
+				ZB_ZCL_ARRAY_SIZE(identify_attr_list, zb_zcl_attr_t),                 \
+				(identify_attr_list),                                                 \
+				ZB_ZCL_CLUSTER_SERVER_ROLE,                                           \
+				ZB_ZCL_MANUF_CODE_INVALID),                                           \
+			ZB_ZCL_CLUSTER_DESC(                                                      \
+				ZB_ZCL_CLUSTER_ID_BASIC,                                              \
+				ZB_ZCL_ARRAY_SIZE(basic_attr_list, zb_zcl_attr_t),                    \
+				(basic_attr_list),                                                    \
+				ZB_ZCL_CLUSTER_SERVER_ROLE,                                           \
+				ZB_ZCL_MANUF_CODE_INVALID),                                           \
+			ZB_ZCL_CLUSTER_DESC(                                                      \
+				ZB_ZCL_CLUSTER_ID_TEMP_MEASUREMENT,                                   \
+				ZB_ZCL_ARRAY_SIZE(temperature_measure_attr_list, zb_zcl_attr_t),      \
+				(temperature_measure_attr_list),                                      \
+				ZB_ZCL_CLUSTER_SERVER_ROLE,                                           \
+				ZB_ZCL_MANUF_CODE_INVALID),                                           \
+			ZB_ZCL_CLUSTER_DESC(                                                      \
+				ZB_ZCL_CLUSTER_ID_REL_HUMIDITY_MEASUREMENT,                           \
+				ZB_ZCL_ARRAY_SIZE(humidity_measure_attr_list, zb_zcl_attr_t),         \
+				(humidity_measure_attr_list),                                         \
+				ZB_ZCL_CLUSTER_SERVER_ROLE,                                           \
+				ZB_ZCL_MANUF_CODE_INVALID),                                           \
+			ZB_ZCL_CLUSTER_DESC(                                                      \
+				ZB_ZCL_CLUSTER_ID_POWER_CONFIG,                                       \
+				ZB_ZCL_ARRAY_SIZE(power_config_attr_list, zb_zcl_attr_t),             \
+				(power_config_attr_list),                                             \
+				ZB_ZCL_CLUSTER_SERVER_ROLE,                                           \
 				ZB_ZCL_MANUF_CODE_INVALID)}
 
-#define ZB_ZCL_DECLARE_HA_DIMMABLE_LIGHT_SIMPLE_DESC(ep_name, ep_id, in_clust_num, out_clust_num) \
+#define ZB_ZCL_DECLARE_HA_DIMMABLE_LIGHT_SIMPLE_DESC_WITH_CO2(ep_name, ep_id, in_clust_num, out_clust_num) \
+	ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                          \
+	ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num)                                           \
+	simple_desc_##ep_name =                                                                       \
+		{                                                                                         \
+			ep_id,                                                                                \
+			ZB_AF_HA_PROFILE_ID,                                                                  \
+			ZB_HA_TEMPERATURE_SENSOR_DEVICE_ID,                                                   \
+			ZB_DEVICE_VERSION,                                                                    \
+			0,                                                                                    \
+			in_clust_num,                                                                         \
+			out_clust_num,                                                                        \
+				{ZB_ZCL_CLUSTER_ID_BASIC,                                                             \
+				 ZB_ZCL_CLUSTER_ID_IDENTIFY,                                                          \
+				 ZB_ZCL_CLUSTER_ID_TEMP_MEASUREMENT,                                                  \
+				 ZB_ZCL_CLUSTER_ID_REL_HUMIDITY_MEASUREMENT,                                          \
+				 ZB_ZCL_CLUSTER_ID_CONCENTRATION_MEASUREMENT,                                         \
+				 ZB_ZCL_CLUSTER_ID_POWER_CONFIG}}
+
+#define ZB_ZCL_DECLARE_HA_DIMMABLE_LIGHT_SIMPLE_DESC_NO_CO2(ep_name, ep_id, in_clust_num, out_clust_num) \
 	ZB_DECLARE_SIMPLE_DESC(in_clust_num, out_clust_num);                                          \
 	ZB_AF_SIMPLE_DESC_TYPE(in_clust_num, out_clust_num)                                           \
 	simple_desc_##ep_name =                                                                       \
@@ -72,20 +134,34 @@
 			 ZB_ZCL_CLUSTER_ID_IDENTIFY,                                                          \
 			 ZB_ZCL_CLUSTER_ID_TEMP_MEASUREMENT,                                                  \
 			 ZB_ZCL_CLUSTER_ID_REL_HUMIDITY_MEASUREMENT,                                          \
-			 ZB_ZCL_CLUSTER_ID_CONCENTRATION_MEASUREMENT,										  \
 			 ZB_ZCL_CLUSTER_ID_POWER_CONFIG}}
 
-#define ZB_DECLARE_DIMMABLE_LIGHT_EP(ep_name, ep_id, cluster_list)                                                     \
-	ZB_ZCL_DECLARE_HA_DIMMABLE_LIGHT_SIMPLE_DESC(ep_name, ep_id,                                                       \
-												 ZB_DIMMABLE_LIGHT_IN_CLUSTER_NUM, ZB_DIMMABLE_LIGHT_OUT_CLUSTER_NUM); \
+#define ZB_DECLARE_DIMMABLE_LIGHT_EP_WITH_CO2(ep_name, ep_id, cluster_list)                                           \
+	ZB_ZCL_DECLARE_HA_DIMMABLE_LIGHT_SIMPLE_DESC_WITH_CO2(ep_name, ep_id,                                             \
+														 ZB_DIMMABLE_LIGHT_IN_CLUSTER_NUM_WITH_CO2, ZB_DIMMABLE_LIGHT_OUT_CLUSTER_NUM); \
 	ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info##ep_name,                                                        \
-									   ZB_DIMMABLE_LIGHT_REPORT_ATTR_COUNT);                                           \
+										   ZB_DIMMABLE_LIGHT_REPORT_ATTR_COUNT_WITH_CO2);                                  \
 	ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID,                                                   \
 								0,                                                                                     \
 								NULL,                                                                                  \
 								ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,                  \
 								(zb_af_simple_desc_1_1_t *)&simple_desc_##ep_name,                                     \
-								ZB_DIMMABLE_LIGHT_REPORT_ATTR_COUNT,                                                   \
+								ZB_DIMMABLE_LIGHT_REPORT_ATTR_COUNT_WITH_CO2,                                          \
+								reporting_info##ep_name,                                                               \
+								0,                                                                                     \
+								NULL)
+
+#define ZB_DECLARE_DIMMABLE_LIGHT_EP_NO_CO2(ep_name, ep_id, cluster_list)                                             \
+	ZB_ZCL_DECLARE_HA_DIMMABLE_LIGHT_SIMPLE_DESC_NO_CO2(ep_name, ep_id,                                               \
+														 ZB_DIMMABLE_LIGHT_IN_CLUSTER_NUM_NO_CO2, ZB_DIMMABLE_LIGHT_OUT_CLUSTER_NUM); \
+	ZBOSS_DEVICE_DECLARE_REPORTING_CTX(reporting_info##ep_name,                                                        \
+										   ZB_DIMMABLE_LIGHT_REPORT_ATTR_COUNT_NO_CO2);                                  \
+	ZB_AF_DECLARE_ENDPOINT_DESC(ep_name, ep_id, ZB_AF_HA_PROFILE_ID,                                                   \
+								0,                                                                                     \
+								NULL,                                                                                  \
+								ZB_ZCL_ARRAY_SIZE(cluster_list, zb_zcl_cluster_desc_t), cluster_list,                  \
+								(zb_af_simple_desc_1_1_t *)&simple_desc_##ep_name,                                     \
+								ZB_DIMMABLE_LIGHT_REPORT_ATTR_COUNT_NO_CO2,                                            \
 								reporting_info##ep_name,                                                               \
 								0,                                                                                     \
 								NULL)


### PR DESCRIPTION
## Summary
- make SCD4X optional at runtime based on devicetree
- default build to no-SCD4X via boards/no_scd4x.overlay
- split Zigbee endpoint/cluster declarations so CO2 cluster (0x040D) is only exposed when SCD4X is enabled
- add explicit make targets: build-no-scd4x and build-scd4x

## Validation
- make build (default no-SCD4X) succeeds
- make build-scd4x succeeds
- ZHA interview for no-SCD4X device shows input clusters [0x0000, 0x0001, 0x0003, 0x0402, 0x0405] (no 0x040D)
